### PR TITLE
Add `isFile` property to config

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,8 +1,8 @@
 {
   "components" : [
-    { "path": "app", "label": "App", "insertPath": "./"},
-    { "path": "example.functions", "label": "Serverless function", "insertPath": "./"},
-    { "path": "crm-card-side.js", "label": "CRM card (side panel)", "insertPath": "./"},
-    { "path": "crm-card-middle.js", "label": "CRM card (middle panel)", "insertPath": "./"}
+    { "path": "app", "label": "App", "insertPath": "./", "isFile": false},
+    { "path": "example.functions", "label": "Serverless function", "insertPath": "./", "isFile": false},
+    { "path": "crm-card-side.js", "label": "CRM card (side panel)", "insertPath": "./", "isFile": true},
+    { "path": "crm-card-middle.js", "label": "CRM card (middle panel)", "insertPath": "./", "isFile": true}
   ]
 }


### PR DESCRIPTION
## Description and Context

I've added an `isFile` property to the `config.json` file, so we can easily differentiate between folder and file components. We download the contents from GitHub differently depending on whether the component is a folder or file. 