### PR TITLE
Add type property to config

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,8 +1,8 @@
 {
   "components" : [
-    { "path": "app", "label": "App", "insertPath": "./", "isFile": false},
-    { "path": "example.functions", "label": "Serverless function", "insertPath": "./", "isFile": false},
-    { "path": "crm-card-side.js", "label": "CRM card (side panel)", "insertPath": "./", "isFile": true},
-    { "path": "crm-card-middle.js", "label": "CRM card (middle panel)", "insertPath": "./", "isFile": true}
+    { "path": "app", "label": "App", "insertPath": "./", "isFile": false, "type": "PRIVATE_APP"},
+    { "path": "example.functions", "label": "Serverless function", "insertPath": "./", "isFile": false, "type": "APP_FUNCTION"},
+    { "path": "crm-card-side.js", "label": "CRM card (side panel)", "insertPath": "./", "isFile": true, "type": "CRM_CARD_V2"},
+    { "path": "crm-card-middle.js", "label": "CRM card (middle panel)", "insertPath": "./", "isFile": true, "type": "CRM_CARD_V2"}
   ]
 }


### PR DESCRIPTION
## Description and Context

In the PR, I'm adding a `type` property to the `config.json` file. This will help us determine whether to add any extensions to a file or folder name and what those extensions should be. 