### PR TITLE
Add platform versions and empty template

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,8 +7,8 @@
   {
     "name": "no-template",
     "label": "No template",
-    "path": null,
-    "insertPath": null
+    "path": "projects/no-template",
+    "insertPath": "./"
   },
   {
     "name": "getting-started",

--- a/projects/no-template/hsproject.json
+++ b/projects/no-template/hsproject.json
@@ -1,5 +1,5 @@
 {
-  "name": "getting-started-template",
+  "name": "no-template",
   "srcDir": "src",
   "platformVersion": "2023.1"
 }


### PR DESCRIPTION
This adds platform versions to the `.hsproject.json` files and sets up an empty template so that newly created empty projects receive the proper platform version

See https://github.com/HubSpot/hubspot-cli/pull/916

@kemmerle @brandenrodgers 