### PR TITLE
Ignore more .env variants

### DIFF
--- a/projects/getting-started-template/.gitignore
+++ b/projects/getting-started-template/.gitignore
@@ -69,8 +69,7 @@ typings/
 .yarn-integrity
 
 # dotenv environment variables file
-.env
-.env.test
+.env*
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache


### PR DESCRIPTION
Generalize the gitignore rule for dotenv files.