### PR TITLE
fix: Update the post install command to work with powershell

### DIFF
--- a/projects/getting-started-template/package.json
+++ b/projects/getting-started-template/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Basic example of a UI Extension built with HubSpot's React developer tools",
   "scripts": {
-    "postinstall": "cd ./src/app/extensions/ && npm install; cd ../app.functions && npm install",
+    "postinstall": "cd ./src/app/extensions/ && npm install && cd ../app.functions && npm install",
     "build": "npm run build --prefix ./src/app/extensions/"
   },
   "author": "HubSpot",


### PR DESCRIPTION
Running an `npm install` from the project root was causing a syntax error in powershell because `npm install;` was parsed as `npm` and `install;`, so `npm` would rightfully error saying `install;` is not a valid command.