### PR TITLE
Bump platformVersion to 2023.2

### DIFF
--- a/projects/getting-started-template/hsproject.json
+++ b/projects/getting-started-template/hsproject.json
@@ -1,5 +1,5 @@
 {
   "name": "Get Started Project",
   "srcDir": "src",
-  "platformVersion": "2023.1"
+  "platformVersion": "2023.2"
 }

--- a/projects/no-template/hsproject.json
+++ b/projects/no-template/hsproject.json
@@ -1,5 +1,5 @@
 {
   "name": "Empty Project",
   "srcDir": "src",
-  "platformVersion": "2023.1"
+  "platformVersion": "2023.2"
 }


### PR DESCRIPTION
This bumps the `platformVersion` field to `2023.2`. We can keep this staged for now until we do the formal release.

cc @brandenrodgers @robrown-hubspot 