### PR TITLE
Remove conversation subscription in webhooks in public app template

### DIFF
--- a/projects/private-app-getting-started-template/src/app/app.json
+++ b/projects/private-app-getting-started-template/src/app/app.json
@@ -2,7 +2,7 @@
   "name": "Get started App",
   "description": "This is an example private app that shows a custom card on the Contact record tab built with React-based frontend. This card demonstrates a simple handshake with HubSpot's serverless backend.",
   "uid": "get_started_app",
-  "scopes": ["crm.objects.contacts.read", "crm.objects.contacts.write", "conversations.read"],
+  "scopes": ["crm.objects.contacts.read", "crm.objects.contacts.write"],
   "public": false,
   "extensions": {
     "crm": {

--- a/projects/private-app-getting-started-template/src/app/webhooks/webhooks.json
+++ b/projects/private-app-getting-started-template/src/app/webhooks/webhooks.json
@@ -32,10 +32,6 @@
       {
         "subscriptionType": "contact.privacyDeletion",
         "active": true
-      },
-      {
-        "subscriptionType": "conversation.creation",
-        "active": true
       }
     ]
   }

--- a/projects/public-app-getting-started-template/src/app/public-app.json
+++ b/projects/public-app-getting-started-template/src/app/public-app.json
@@ -5,7 +5,7 @@
   "allowedUrls": ["https://api.hubapi.com"],
   "auth": {
     "redirectUrls": ["http://localhost:3000/oauth-callback"],
-    "requiredScopes": ["crm.objects.contacts.read", "crm.objects.contact.write"],
+    "requiredScopes": ["crm.objects.contacts.read"],
     "optionalScopes": [],
     "conditionallyRequiredScopes": []
   },

--- a/projects/public-app-getting-started-template/src/app/public-app.json
+++ b/projects/public-app-getting-started-template/src/app/public-app.json
@@ -5,7 +5,7 @@
   "allowedUrls": ["https://api.hubapi.com"],
   "auth": {
     "redirectUrls": ["http://localhost:3000/oauth-callback"],
-    "requiredScopes": ["crm.objects.contacts.read", "conversations.read"],
+    "requiredScopes": ["crm.objects.contacts.read", "crm.objects.contact.write"],
     "optionalScopes": [],
     "conditionallyRequiredScopes": []
   },

--- a/projects/public-app-getting-started-template/src/app/public-app.json
+++ b/projects/public-app-getting-started-template/src/app/public-app.json
@@ -5,7 +5,7 @@
   "allowedUrls": ["https://api.hubapi.com"],
   "auth": {
     "redirectUrls": ["http://localhost:3000/oauth-callback"],
-    "requiredScopes": ["crm.objects.contacts.read"],
+    "requiredScopes": ["crm.objects.contacts.read", "crm.objects.contacts.write"],
     "optionalScopes": [],
     "conditionallyRequiredScopes": []
   },

--- a/projects/public-app-getting-started-template/src/app/webhooks.json
+++ b/projects/public-app-getting-started-template/src/app/webhooks.json
@@ -32,10 +32,6 @@
       {
         "subscriptionType": "contact.privacyDeletion",
         "active": true
-      },
-      {
-        "subscriptionType": "conversation.creation",
-        "active": true
       }
     ]
   }


### PR DESCRIPTION
## Description and Context
After a discussion in Slack, we have decided to remove the conversation subscription in the public app getting started template. This is to streamline the webhook examples provided in the template. 

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address any feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@kporter999 