### PR TITLE
UI Extensions code samples link is broken

### DIFF
--- a/components/example-app/extensions/Example.jsx
+++ b/components/example-app/extensions/Example.jsx
@@ -65,7 +65,7 @@ const Extension = ({ context, runServerless, sendAlert }) => {
           Quickstart Guide
         </Link>
         , or check out our{" "}
-        <Link href="https://github.com/HubSpot/ui-extensions-react-examples">
+        <Link href="https://github.com/HubSpot/ui-extensions-examples">
           code Samples
         </Link>
         .


### PR DESCRIPTION
## Background

I was testing `hs project create` flow for a demo and noticed one of the links is broken.

This was moved from `ui-extensions-react-examples` to `ui-extensions-examples` and I just noticed the link in the default card footer is broken.

### Before:
![Kapture 2024-09-02 at 20 16 52](https://github.com/user-attachments/assets/a0c0a443-a33d-4f3d-a479-03361f9cbb6e)

### After:
Link points here:
<img width="1083" alt="Screenshot 2024-09-02 at 8 18 12 PM" src="https://github.com/user-attachments/assets/a3b39aa2-1a88-4d65-b73b-1a70582f94b4">
