### PR TITLE
Removing the beta label on public app template

### DIFF
--- a/config.json
+++ b/config.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "getting-started-public-app",
-      "label": "CRM getting started project with public apps (BETA)",
+      "label": "CRM getting started project with public apps",
       "path": "projects/public-app-getting-started-template",
       "insertPath": "./"
     },


### PR DESCRIPTION
There's no need to specify this because our BE will return errors with more info about the betas