### PR TITLE
Modify allowedUrls in the public app getting started template

### DIFF
--- a/projects/public-app-getting-started-template/src/app/public-app.json
+++ b/projects/public-app-getting-started-template/src/app/public-app.json
@@ -2,7 +2,7 @@
   "name": "Get started with public apps",
   "uid": "get-started-public-app",
   "description": "An example to demonstrate how to build a public app with developer projects.",
-  "allowedUrls": ["https://api.hubapi.com"],
+  "allowedUrls": ["https://api.yourplatform.com"],
   "auth": {
     "redirectUrls": ["http://localhost:3000/oauth-callback"],
     "requiredScopes": ["crm.objects.contacts.read", "crm.objects.contacts.write"],


### PR DESCRIPTION
Modify allowedUrls in the public app getting started template to clearly indicate to the developer that they can invoke developer owned backends and not Hubspot public APIs through hubspot.fetch()