### PR TITLE
feat: Add scim templates

### DIFF
--- a/2025.2/components/scim/scim-hsmeta.json
+++ b/2025.2/components/scim/scim-hsmeta.json
@@ -1,0 +1,7 @@
+{
+  "uid": "scim",
+  "type": "scim",
+  "config": {
+    "roleSyncEnabled": false
+  }
+}

--- a/2025.2/config.json
+++ b/2025.2/config.json
@@ -63,6 +63,14 @@
       "parentType": "app",
       "supportedAuthTypes": ["oauth", "static" ],
       "supportedDistributions": ["private", "marketplace"]
+    },
+    {
+      "path": "components/scim",
+      "type": "scim",
+      "label": "SCIM Integration",
+      "parentType": "app",
+      "supportedAuthTypes": ["static"],
+      "supportedDistributions": ["private"]
     }
   ]
 }

--- a/config.json
+++ b/config.json
@@ -17,6 +17,11 @@
       "path": "projects/public-app-getting-started-template"
     },
     {
+      "name": "scim-app",
+      "label": "Starter project for integrating with SCIM",
+      "path": "projects/scim-app-template"
+    },
+    {
       "name": "no-template",
       "label": "<Create an empty project (no template)>",
       "path": "projects/no-template"

--- a/projects/scim-app-template/hsproject.json
+++ b/projects/scim-app-template/hsproject.json
@@ -1,0 +1,5 @@
+{
+  "name": "scim-integration-app-template",
+  "srcDir": "src",
+  "platformVersion": "2025.2"
+}

--- a/projects/scim-app-template/src/app/scim-app-hsmeta.json
+++ b/projects/scim-app-template/src/app/scim-app-hsmeta.json
@@ -1,0 +1,25 @@
+{
+  "uid": "scim_app",
+  "type": "app",
+  "config": {
+    "description": "An example to demonstrate how to build a scim private app with developer projects.",
+    "name": "scim app",
+    "distribution": "private",
+    "auth": {
+      "type": "static",
+      "requiredScopes": [
+        "crm.objects.users.read",
+        "crm.objects.users.write",
+        "settings.users.read",
+        "settings.users.write"
+      ],
+      "optionalScopes": [],
+      "conditionallyRequiredScopes": []
+    },
+    "permittedUrls": {
+      "fetch": [],
+      "iframe": [],
+      "img": []
+    }
+  }
+}

--- a/projects/scim-app-template/src/app/scim/scim-hsmeta.json
+++ b/projects/scim-app-template/src/app/scim/scim-hsmeta.json
@@ -1,0 +1,7 @@
+{
+  "uid": "scim",
+  "type": "scim",
+  "config": {
+    "roleSyncEnabled": false
+  }
+}


### PR DESCRIPTION
This adds a project template that can be used to create a new SCIM app:

```sh
hs project create --template scim-app
```

It also adds a component template for adding the SCIM component to an existing app:

```sh
hs project add --type="components/scim"
```