### PR TITLE
chore: Add `cliSelector` field

### DIFF
--- a/2025.2/config.json
+++ b/2025.2/config.json
@@ -67,7 +67,7 @@
     {
       "path": "components/workflow-actions-tool",
       "type": "workflow-action",
-      "cliSelector": "workflow-action",
+      "cliSelector": "workflow-action-tool",
       "label": "Agent Tool",
       "parentType": "app",
       "supportedAuthTypes": ["oauth", "static" ],

--- a/2025.2/config.json
+++ b/2025.2/config.json
@@ -67,6 +67,7 @@
     {
       "path": "components/workflow-actions-tool",
       "type": "workflow-action",
+      "cliSelector": "workflow-action-tool",
       "label": "Agent Tool",
       "parentType": "app",
       "supportedAuthTypes": ["oauth", "static" ],

--- a/2025.2/config.json
+++ b/2025.2/config.json
@@ -65,6 +65,14 @@
       "supportedDistributions": ["private", "marketplace"]
     },
     {
+      "path": "components/workflow-actions-tool",
+      "type": "workflow-action",
+      "label": "Agent Tool",
+      "parentType": "app",
+      "supportedAuthTypes": ["oauth", "static" ],
+      "supportedDistributions": ["private", "marketplace"]
+    },
+    {
       "path": "components/scim",
       "type": "scim",
       "label": "SCIM Integration",


### PR DESCRIPTION
Adding a `cliSelector` field that we can use to match the `--features` flag in the `hs porject add` and `hs project create`.  We were previously using the `type` field, which prevents us from having multiple examples of the same component type, because we will add both of them.