### PR TITLE
Make Webhooks inactive by default 

### DIFF
--- a/projects/private-app-getting-started-template/src/app/webhooks/webhooks.json
+++ b/projects/private-app-getting-started-template/src/app/webhooks/webhooks.json
@@ -9,29 +9,29 @@
         "subscriptionType": "object.propertyChange",
         "objectName": "contact",
         "propertyName": "firstname",
-        "active": true
+        "active": false
       },
       {
         "subscriptionType": "object.creation",
         "objectName": "contact",
-        "active": true
+        "active": false
       }
     ],
     "legacyCrmObjects": [
       {
         "subscriptionType": "contact.propertyChange",
         "propertyName": "lastname",
-        "active": true
+        "active": false
       },
       {
         "subscriptionType": "contact.deletion",
-        "active": true
+        "active": false
       }
     ],
     "hubEvents": [
       {
         "subscriptionType": "contact.privacyDeletion",
-        "active": true
+        "active": false
       }
     ]
   }

--- a/projects/public-app-getting-started-template/src/app/webhooks/webhooks.json
+++ b/projects/public-app-getting-started-template/src/app/webhooks/webhooks.json
@@ -9,29 +9,29 @@
         "subscriptionType": "object.propertyChange",
         "objectName": "contact",
         "propertyName": "firstname",
-        "active": true
+        "active": false
       },
       {
         "subscriptionType": "object.creation",
         "objectName": "contact",
-        "active": true
+        "active": false
       }
     ],
     "legacyCrmObjects": [
       {
         "subscriptionType": "contact.propertyChange",
         "propertyName": "lastname",
-        "active": true
+        "active": false
       },
       {
         "subscriptionType": "contact.deletion",
-        "active": true
+        "active": false
       }
     ],
     "hubEvents": [
       {
         "subscriptionType": "contact.privacyDeletion",
-        "active": true
+        "active": false
       }
     ]
   }


### PR DESCRIPTION
This suggestion came from our PM Chris:

 "Hi Jud, I'm porting over and tidying up the docs for creating a project-built private app on 2025.1 (since that's the current recourse for folks who still want to create serverless functions), and when I ran `hs project create --platformVersion 2025.1`, I noticed that the boilerplate project includes a webhook config file in the webhooks directory that are active by default.

I can advise that users set the corresponding active values to false , but I wonder if they should be inactive by default. There isn't a huge risk since the URL is http://example.com/webhook but feels like we don't necessarily want CRM data leaking by default when users might just upload their project and might not be expecting webhooks to be auto-enabled."

We decided to reduce confusion related to webhooks being off by default, we could add a warning log indicating that some subscriptions are inactve during the build. 

`[WARNING] This build contains 3 inactive webhook subscriptions. Subscriptions must be set to active in order to execute`

This warning should reduce confusion about devs not knowing that their subscriptions are in-active .