### PR TITLE
Remove oauth from app function endpoint supportedAuthTypes

### DIFF
--- a/2026.03-beta/config.json
+++ b/2026.03-beta/config.json
@@ -48,7 +48,7 @@
       "type": "app-function",
       "cliSelector": "app-function-endpoint",
       "parentType": "app",
-      "supportedAuthTypes": ["oauth", "static"],
+      "supportedAuthTypes": ["static"],
       "supportedDistributions": ["private"]
     },
     {

--- a/2026.03/config.json
+++ b/2026.03/config.json
@@ -48,7 +48,7 @@
       "cliSelector": "app-function-endpoint",
       "type": "app-function",
       "parentType": "app",
-      "supportedAuthTypes": ["oauth", "static"],
+      "supportedAuthTypes": ["static"],
       "supportedDistributions": ["private"]
     },
     {

--- a/2026.09-beta/config.json
+++ b/2026.09-beta/config.json
@@ -48,7 +48,7 @@
       "cliSelector": "app-function-endpoint",
       "type": "app-function",
       "parentType": "app",
-      "supportedAuthTypes": ["oauth", "static"],
+      "supportedAuthTypes": ["static"],
       "supportedDistributions": ["private"]
     },
     {


### PR DESCRIPTION
## Description and Context

Removes `oauth` from `supportedAuthTypes` in the "App Function (endpoint)" component entry across all config versions that define it (`2026.03`, `2026.03-beta`, `2026.09-beta`). The endpoint app function type now only supports `static` auth, consistent with the existing "App Function (private)" entry. The `2025.2` config was not changed as it uses a different "Public Function" entry without a dedicated endpoint variant.

