### PR TITLE
chore: update @hubspot/api-client to ^14.0.1 in serverless functions

### DIFF
--- a/2025.2/components/functions/src/app/functions/package.json
+++ b/2025.2/components/functions/src/app/functions/package.json
@@ -2,6 +2,6 @@
   "name": "example-function",
   "version": "0.1.0",
   "dependencies": {
-    "@hubspot/api-client": "^12.1.0"
+    "@hubspot/api-client": "^14.0.1"
   }
 }

--- a/2026.03-beta/components/functions-endpoint/src/app/functions/package.json
+++ b/2026.03-beta/components/functions-endpoint/src/app/functions/package.json
@@ -2,6 +2,6 @@
   "name": "example-function",
   "version": "0.1.0",
   "dependencies": {
-    "@hubspot/api-client": "^12.1.0"
+    "@hubspot/api-client": "^14.0.1"
   }
 }

--- a/2026.03-beta/components/functions-private/src/app/functions/package.json
+++ b/2026.03-beta/components/functions-private/src/app/functions/package.json
@@ -2,6 +2,6 @@
   "name": "example-function",
   "version": "0.1.0",
   "dependencies": {
-    "@hubspot/api-client": "^12.1.0"
+    "@hubspot/api-client": "^14.0.1"
   }
 }

--- a/2026.03/components/functions-endpoint/src/app/functions/package.json
+++ b/2026.03/components/functions-endpoint/src/app/functions/package.json
@@ -2,6 +2,6 @@
   "name": "example-function",
   "version": "0.1.0",
   "dependencies": {
-    "@hubspot/api-client": "^12.1.0"
+    "@hubspot/api-client": "^14.0.1"
   }
 }

--- a/2026.03/components/functions-private/src/app/functions/package.json
+++ b/2026.03/components/functions-private/src/app/functions/package.json
@@ -2,6 +2,6 @@
   "name": "example-function",
   "version": "0.1.0",
   "dependencies": {
-    "@hubspot/api-client": "^12.1.0"
+    "@hubspot/api-client": "^14.0.1"
   }
 }

--- a/2026.09-beta/components/functions-endpoint/src/app/functions/package.json
+++ b/2026.09-beta/components/functions-endpoint/src/app/functions/package.json
@@ -2,6 +2,6 @@
   "name": "example-function",
   "version": "0.1.0",
   "dependencies": {
-    "@hubspot/api-client": "^12.1.0"
+    "@hubspot/api-client": "^14.0.1"
   }
 }

--- a/2026.09-beta/components/functions-private/src/app/functions/package.json
+++ b/2026.09-beta/components/functions-private/src/app/functions/package.json
@@ -2,6 +2,6 @@
   "name": "example-function",
   "version": "0.1.0",
   "dependencies": {
-    "@hubspot/api-client": "^12.1.0"
+    "@hubspot/api-client": "^14.0.1"
   }
 }

--- a/components/example-app/app.functions/package.json
+++ b/components/example-app/app.functions/package.json
@@ -4,6 +4,6 @@
   "author": "HubSpot",
   "license": "MIT",
   "dependencies": {
-    "@hubspot/api-client": "^7.0.1"
+    "@hubspot/api-client": "^14.0.1"
   }
 }

--- a/projects/private-app-getting-started-template/src/app/app.functions/package.json
+++ b/projects/private-app-getting-started-template/src/app/app.functions/package.json
@@ -4,6 +4,6 @@
   "author": "HubSpot",
   "license": "MIT",
   "dependencies": {
-    "@hubspot/api-client": "^7.0.1"
+    "@hubspot/api-client": "^14.0.1"
   }
 }


### PR DESCRIPTION
## Description and Context

Updates `@hubspot/api-client` from `^7.0.1` / `^12.1.0` to `^14.0.1` (the current latest) across all 9 serverless function `package.json` files spanning the `2025.2`, `2026.03`, `2026.03-beta`, `2026.09-beta`, `components/example-app`, and `projects/private-app-getting-started-template` directories.

## Screenshots

N/A — dependency version bump only, no runtime behavior changes.

## TODO

<!-- Is there anything you're leaving behind that should be done? -->

## Who to Notify

<!-- /cc those you wish to know about the PR -->
