### PR TITLE
docs: rewrite README for external contributors and add Claude skills

### DIFF
--- a/.claude/skills/add-component/SKILL.md
+++ b/.claude/skills/add-component/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: add-component
+description: >
+  Use this skill when adding a new component type to the hubspot-project-components repo.
+  Triggers include "add a new component", "add a component type", "scaffold a new component",
+  "create a template for a new feature type", or any mention of adding a component to a platform
+  version directory. Prompts the user for required inputs before creating any files.
+---
+
+# Add Component
+
+This skill adds a new component type template to one or more platform version directories and registers it in the corresponding `config.json`.
+
+## Step 1: Gather inputs
+
+Ask all questions in a single message and wait for answers before proceeding.
+
+1. **Platform version(s)** — which version directory (or directories) to add this component to (e.g., `2026.03`, `2026.09-beta`). List available versions by running `ls -d */` in the repo root.
+2. **Component label** — the human-readable name shown in the CLI (e.g., `"Custom Webhook Handler"`).
+3. **Component type** — the `type` value used in `config.json` and `-hsmeta.json` (e.g., `webhooks`, `card`, `app-function`). Look at existing `config.json` entries for examples.
+4. **Directory name** — the subdirectory name under `components/` (e.g., `my-webhooks`). Defaults to the component type with a plural if appropriate.
+5. **Parent type** — which parent component this attaches to. Almost always `app`.
+6. **Supported auth types** — one or both of `oauth`, `static`.
+7. **Supported distributions** — one or both of `private`, `marketplace`.
+8. **CLI selector override** — an optional `cliSelector` value if the CLI command name differs from the `type` (check existing entries in `config.json` for examples — most components don't need this).
+9. **Closest existing component to base the template on** — which existing component's file structure to copy as a starting point. Show the list from `{version}/components/` for the user to choose from.
+
+## Step 2: Confirm the plan
+
+Before making any changes, show the user a summary:
+
+```
+Adding component:
+  Label:         {label}
+  Type:          {type}
+  Directory:     {version}/components/{dirName}/
+  Parent type:   {parentType}
+  Auth types:    {authTypes}
+  Distributions: {distributions}
+  Based on:      {sourceComponent}
+
+config.json entry:
+{previewJsonEntry}
+
+Proceed?
+```
+
+## Step 3: Copy template files
+
+For each target platform version:
+
+```bash
+cp -r {version}/components/{sourceComponent} {version}/components/{dirName}
+```
+
+Then update the `-hsmeta.json` file inside the copied directory:
+- Set `"type"` to the new component type
+- Generate a new `"uid"` value (use the format `{dirName}-{randomSuffix}` where the suffix is a short alphanumeric string)
+- Remove or update any label/name fields that reflect the source component
+
+## Step 4: Update config.json
+
+Add a new entry to the `"components"` array in `{version}/config.json`:
+
+```json
+{
+  "path": "components/{dirName}",
+  "label": "{label}",
+  "type": "{type}",
+  "parentType": "{parentType}",
+  "supportedAuthTypes": [{authTypes}],
+  "supportedDistributions": [{distributions}]
+}
+```
+
+Include `"cliSelector": "{cliSelector}"` only if the user provided one.
+
+## Step 5: Report what was created
+
+Tell the user:
+- The directories and files created
+- The `config.json` entry added
+- What they should customize in the new component directory (the `-hsmeta.json` fields, the UI entry point if it's a card/settings component, or the function handler if it's an app-function)
+- If the component type is new to HubSpot (not just new to this repo), remind them to document it in `defaultFiles/CLAUDE.md` and `defaultFiles/AGENTS.md`

--- a/.claude/skills/add-platform-version/SKILL.md
+++ b/.claude/skills/add-platform-version/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: add-platform-version
+description: >
+  Use this skill when adding a new HubSpot platform version to the hubspot-project-components repo.
+  Triggers include "add a new platform version", "create a new version directory", "scaffold 2026.09",
+  "add support for a new platform release", or any mention of adding a versioned directory to this repo.
+  Prompts the user for the required inputs before making any changes.
+---
+
+# Add Platform Version
+
+This skill scaffolds a new platform version directory by copying an existing version and updating version-specific references.
+
+## Step 1: Gather inputs
+
+Ask the user for the following. Ask all questions in a single message and wait for answers before proceeding.
+
+1. **New version string** — the platform version identifier (e.g., `2026.09`). This becomes the directory name.
+2. **Is this a beta release?** — if yes, append `-beta` to the directory name (e.g., `2026.09-beta`).
+3. **Source version to copy from** — which existing version directory to use as the base. Default to the most recent non-beta version. List the available options by running `ls -d */` in the repo root and showing version directories only.
+
+## Step 2: Determine names
+
+- **Source directory**: the version the user chose to copy from (e.g., `2026.03`)
+- **Target directory**: new version string, with `-beta` appended if applicable (e.g., `2026.09-beta`)
+
+Confirm both with the user before making any changes: "I'll copy `{source}` → `{target}`. Proceed?"
+
+## Step 3: Copy the directory
+
+```bash
+cp -r {source} {target}
+```
+
+## Step 4: Update version references
+
+Update the `platformVersion` field in `{target}/defaultFiles/hsproject.json` to the new version string (without the `-beta` suffix — `platformVersion` is always the base version):
+
+```json
+{
+  "name": "My Project",
+  "srcDir": "src",
+  "platformVersion": "{newVersion}"
+}
+```
+
+Scan `{target}/defaultFiles/HUBSPOT_PROJECTS.md` for any hard-coded version references and update them to the new version.
+
+## Step 5: Report what was created
+
+Tell the user:
+- The directory that was created
+- Which files they should review and customize before the version is ready (particularly `config.json` if component support changed between versions)
+- A reminder to update `defaultFiles/CLAUDE.md` and `defaultFiles/AGENTS.md` if the new version introduces new component types, constraints, or CLI commands
+- If this is a beta, a reminder to rename the directory (drop `-beta`) when the version stabilizes

--- a/README.md
+++ b/README.md
@@ -1,9 +1,129 @@
 ## HubSpot Project Components
 
-In this repository, you can find different components to help you get started with your HubSpot Projects.
+This repository contains the component templates and default files that power the HubSpot CLI's `hs project create` and `hs project add` commands. When a developer creates a new HubSpot project or adds a component feature, the CLI pulls scaffolding from this repo.
 
-### Components
+---
 
-1. An empty project with a basic `hsproject.json` file.
-2. A template to help you get started with private apps using the projects framework.
-3. A template to help you get started with public apps using the projects framework.
+## Repository structure
+
+```
+hubspot-project-components/
+├── {platformVersion}/              # One directory per platform version (e.g., 2026.03, 2026.09-beta)
+│   ├── config.json                 # Defines available parent components and child components
+│   ├── components/                 # One subdirectory per component type
+│   ├── defaultFiles/               # Files copied into every new project
+│   │   ├── hsproject.json          # Project config template
+│   │   ├── HUBSPOT_PROJECTS.md     # Getting-started guide for developers
+│   │   ├── CLAUDE.md               # AI workflow guidance for Claude Code
+│   │   └── AGENTS.md               # AI workflow guidance for other coding agents
+│   └── private-app-get-started-template/   # Full starter project (used by hs project get-started)
+├── projects/                       # Legacy project templates (pre-versioned; kept for backwards compat)
+└── components/                     # Legacy component templates (pre-versioned; kept for backwards compat)
+```
+
+The top-level directories are named after HubSpot platform versions. The CLI resolves which version directory to use based on the `platformVersion` field in the developer's `hsproject.json`.
+
+---
+
+## Key files
+
+### `{version}/config.json`
+
+Drives what the CLI presents when a developer runs `hs project add`. It has two sections:
+
+- **`parentComponents`** — top-level app scaffolds (e.g. "Static Private App", "OAuth Marketplace App"). These are created once per project and live in `src/app/`.
+- **`components`** — child features that attach to a parent app (cards, functions, webhooks, etc.). Each entry declares its `type`, the parent it attaches to (`parentType`), and which auth types and distribution models it supports.
+
+```json
+{
+  "parentComponents": [
+    {
+      "label": "Static Private App",
+      "type": "app",
+      "authType": "static",
+      "distribution": "private",
+      "path": "components/app/static-private"
+    }
+  ],
+  "components": [
+    {
+      "path": "components/cards",
+      "label": "Card",
+      "type": "card",
+      "parentType": "app",
+      "supportedAuthTypes": ["oauth", "static"],
+      "supportedDistributions": ["private", "marketplace"]
+    }
+  ]
+}
+```
+
+The `path` value is relative to the version directory and points to the template files the CLI copies when adding that component.
+
+### `{version}/defaultFiles/`
+
+These files are written into every new HubSpot project at creation time, regardless of which template the developer chose.
+
+| File | Purpose |
+|------|---------|
+| `hsproject.json` | Starter project config with `name`, `srcDir`, and `platformVersion` |
+| `HUBSPOT_PROJECTS.md` | A getting-started guide that lands in the developer's project |
+| `CLAUDE.md` | Guidance for [Claude Code](https://claude.ai/code) — rules for how AI should interact with HubSpot projects, CLI commands, component placement rules, and API constraints |
+| `AGENTS.md` | Same guidance as `CLAUDE.md`, but formatted for other AI coding agents (Cursor, Copilot, etc.) |
+
+`CLAUDE.md` and `AGENTS.md` are the primary AI workflow files. They teach AI coding assistants about HubSpot-specific constraints — which directories components must live in, how `hubspot.fetch` works differently from `window.fetch`, which `hs` CLI commands to use, and so on. Edits to these files affect the AI-assisted developer experience for everyone who creates a new HubSpot project using this platform version.
+
+### `{version}/components/{component-type}/`
+
+Each component directory contains a ready-to-copy file tree. The structure mirrors where the files land inside a developer's `src/` directory:
+
+```
+components/cards/
+└── src/
+    └── app/
+        └── cards/
+            ├── card-hsmeta.json    # Component configuration (type, uid, etc.)
+            ├── NewCard.tsx         # React component entry point
+            ├── package.json
+            ├── tsconfig.json
+            └── eslint.config.js
+```
+
+The `-hsmeta.json` file is what the HubSpot platform reads to understand the component type and configuration. Its shape is version-specific — refer to the existing examples or the [HubSpot developer docs](https://developers.hubspot.com/docs/apps/developer-platform/build-apps/overview) for the allowed fields.
+
+---
+
+## Making changes
+
+### Adding or modifying a component template
+
+1. Find the right platform version directory (e.g. `2026.03/components/cards/`).
+2. Edit the template files. Changes take effect for any developer who adds that component after the CLI picks up the new version of this repo.
+3. If you are adding a brand new component type, also add an entry to `{version}/config.json` under `components` or `parentComponents`.
+
+### Adding a new platform version
+
+1. Copy the most recent stable version directory (e.g. `cp -r 2026.03 2026.09`).
+2. Update `platformVersion` in `defaultFiles/hsproject.json` to match the new version string.
+3. Adjust `components/` and `config.json` to reflect any features added or removed in the new platform version.
+4. Use a `-beta` suffix (e.g. `2026.09-beta`) until the version is stable.
+
+### Editing the AI workflow files
+
+`defaultFiles/CLAUDE.md` and `defaultFiles/AGENTS.md` are identical in content — one targets Claude Code, the other targets other AI agents. If you update one, update the other to keep them in sync.
+
+These files document:
+- **Component placement rules** — which directories each component type must live in
+- **`hubspot.fetch` constraints** — why relative URLs don't work and how the local proxy (`local.json`) works around localhost restrictions during development
+- **CLI command reference** — the full `hs project` and `hs account` command list
+- **Available hooks and actions** — for card and settings UI extension components
+
+---
+
+## Contribution workflow
+
+1. Branch from `main`.
+2. Make changes in the appropriate platform version directory.
+3. Open a PR against `main`. The PR template asks for a description, screenshots for visible changes, and a list of people to notify.
+
+There is no build step or test suite in this repository — changes are template files only.

--- a/README.md
+++ b/README.md
@@ -97,11 +97,15 @@ The `-hsmeta.json` file is what the HubSpot platform reads to understand the com
 
 ### Adding or modifying a component template
 
+> **Claude Code users:** this repo includes an `/add-component` skill that handles steps 1–3 interactively. Run it via `/add-component` in Claude Code and it will prompt you for the required information.
+
 1. Find the right platform version directory (e.g. `2026.03/components/cards/`).
 2. Edit the template files. Changes take effect for any developer who adds that component after the CLI picks up the new version of this repo.
 3. If you are adding a brand new component type, also add an entry to `{version}/config.json` under `components` or `parentComponents`.
 
 ### Adding a new platform version
+
+> **Claude Code users:** this repo includes an `/add-platform-version` skill that handles steps 1–3 interactively. Run it via `/add-platform-version` in Claude Code and it will prompt you for the required information.
 
 1. Copy the most recent stable version directory (e.g. `cp -r 2026.03 2026.09`).
 2. Update `platformVersion` in `defaultFiles/hsproject.json` to match the new version string.


### PR DESCRIPTION
## Description and Context

- Rewrites the three-line README into a full contributor guide covering repo structure, the `config.json` schema, key files (`defaultFiles/`, component templates), and how to make changes
- Documents the AI workflow files (`CLAUDE.md` / `AGENTS.md`) and why they matter for the external developer experience
- Adds two project-level Claude Code skills: `/add-platform-version` (scaffolds a new versioned directory) and `/add-component` (adds a new component type and config entry), both with guided prompts
- Calls out the skills directly in the relevant README sections so contributors using Claude Code know to reach for them

## Screenshots

N/A — documentation and skill files only.

## TODO

## Who to Notify